### PR TITLE
Fix release

### DIFF
--- a/bionic/debian/changelog
+++ b/bionic/debian/changelog
@@ -62,7 +62,7 @@ ignition-common4 (4.0.0~pre1-1~bionic) bionic; urgency=medium
 
   * ignition-common4 4.0.0~pre1-1 release
 
- -- Michael Carroll <mjcarroll@dalinar>  Mon, 22 Mar 2021 18:58:49 -0500
+ -- Michael Carroll <michael@openrobotics.org>  Mon, 22 Mar 2021 18:58:49 -0500
 
 ignition-common4 (3.999.999-1~bionic) bionic; urgency=medium
 

--- a/debian/buster/debian/changelog
+++ b/debian/buster/debian/changelog
@@ -62,7 +62,7 @@ ignition-common4 (4.0.0~pre1-1~buster) buster; urgency=medium
 
   * ignition-common4 4.0.0~pre1-1 release
 
- -- Michael Carroll <mjcarroll@dalinar>  Mon, 22 Mar 2021 18:58:49 -0500
+ -- Michael Carroll <michael@openrobotics.org>  Mon, 22 Mar 2021 18:58:49 -0500
 
 ignition-common4 (3.999.999-1~buster) buster; urgency=medium
 

--- a/focal/debian/changelog
+++ b/focal/debian/changelog
@@ -62,7 +62,7 @@ ignition-common4 (4.0.0~pre1-1~focal) focal; urgency=medium
 
   * ignition-common4 4.0.0~pre1-1 release
 
- -- Michael Carroll <mjcarroll@dalinar>  Mon, 22 Mar 2021 18:58:49 -0500
+ -- Michael Carroll <michael@openrobotics.org>  Mon, 22 Mar 2021 18:58:49 -0500
 
 ignition-common4 (3.999.999-1~focal) focal; urgency=medium
 

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -206,9 +206,9 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Breaks: libignition-common4 (<< 3.0.0~pre5+hg20190228r1b2df90990),
-        libignition-common4-profiler4 (<= 4.5.0+ds-1)
+        libignition-common4-profiler (<= 4.5.0+ds-1)
 Replaces: libignition-common4 (<< 3.0.0~pre5+hg20190228r1b2df90990),
-          libignition-common4-profiler4 (<= 4.5.0+ds-1)
+          libignition-common4-profiler (<= 4.5.0+ds-1)
 Multi-Arch: same
 Description: Collection of useful code used by robotics apps - Profiler libs
  Ignition common is a component in the Ignition framework, a set of

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -1,7 +1,5 @@
 #!/usr/bin/make -f
 
-BUILDHOME = $(CURDIR)/debian/build
-
 %:
 	dh $@
 
@@ -9,16 +7,14 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-override_dh_clean:
-	dh_clean
-	rm -rf $(BUILDHOME)
-
-execute_after_dh_install:
+override_dh_install:
+	dh_install --
 	# need to remove files present in components
 	$(RM) debian/libignition-common4-core-dev/usr/include/ignition/common*/ignition/common/av.hh
 	$(RM) debian/libignition-common4-core-dev/usr/include/ignition/common*/ignition/common/events.hh
 	$(RM) debian/libignition-common4-core-dev/usr/include/ignition/common*/ignition/common/graphics.hh
+	dh_missing --list-missing
 
+# test cannot run in parallel
 override_dh_auto_test:
-	mkdir -p $(BUILDHOME)
-	HOME=$(BUILDHOME) dh_auto_test --no-parallel
+	dh_auto_test --max-parallel=1


### PR DESCRIPTION
The 4.5.1 Bionic release is broken:

```
Unpacking libignition-common4-graphics-dev:amd64 (4.5.1-1~bionic) ...
dpkg: error processing archive /tmp/apt-dpkg-install-cFhVRP/31-libignition-common4-graphics-dev_4.5.1-1~bionic_amd64.deb (--unpack):
 trying to overwrite '/usr/include/ignition/common4/ignition/common/graphics.hh', which is also in package libignition-common4-core-dev:amd6
...
Errors were encountered while processing:
 /tmp/apt-dpkg-install-cFhVRP/25-libignition-common4-av-dev_4.5.1-1~bionic_amd64.deb
 /tmp/apt-dpkg-install-cFhVRP/29-libignition-common4-events-dev_4.5.1-1~bionic_amd64.deb
 /tmp/apt-dpkg-install-cFhVRP/31-libignition-common4-graphics-dev_4.5.1-1~bionic_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

I copied the approach from `ign-common5-release`. Also fixed a warning/error about a bad email on the changelog.

Fixed build: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-common4-debbuilder&build=836)](https://build.osrfoundation.org/view/ign-garden/job/ign-common4-debbuilder/836/)


