### PR TITLE
Fix Ubuntu install

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -225,10 +225,8 @@ Depends: libignition-cmake2-dev (>= 2.8.0),
          libignition-common4-core-dev (= ${binary:Version}),
          libignition-common4-profiler (= ${binary:Version}),
          ${misc:Depends}
-Breaks: libignition-common4-dev (<< 3.0.0~pre5+hg20190228r1b2df90990),
-        libignition-common-dev (<= 4.5.0+ds-1)
-Replaces: libignition-common4-dev (<< 3.0.0~pre5+hg20190228r1b2df90990),
-        libignition-common-dev (<= 4.5.0+ds-1)
+Breaks: libignition-common4-dev (<< 3.0.0~pre5+hg20190228r1b2df90990)
+Replaces: libignition-common4-dev (<< 3.0.0~pre5+hg20190228r1b2df90990)
 Multi-Arch: same
 Description: Collection of useful code used by robotics apps - Profiler dev file
  Ignition common is a component in the Ignition framework, a set of


### PR DESCRIPTION
Can't update common4 on Ubuntu Bionic:

```
$ sudo env LANG=C aptitude dist-upgrade
The following packages will be REMOVED:  
The following packages will be upgraded:
  libignition-common4 libignition-common4-av libignition-common4-av-dev libignition-common4-core-dev libignition-common4-events libignition-common4-events-dev libignition-common4-graphics 
  libignition-common4-graphics-dev libignition-common4-profiler libignition-common4-profiler-dev{b} 
10 packages upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 669 kB of archives. After unpacking 1064 MB will be freed.
The following packages have unmet dependencies:
 libignition-common4-profiler-dev : Breaks: libignition-common-dev (<= 4.5.0+ds-1) but 1.1.1-1~bionic is installed
The following actions will resolve these dependencies:

      Keep the following packages at their current version:    
1)      libignition-common4 [4.5.0-1~bionic (now)]             
2)      libignition-common4-av [4.5.0-1~bionic (now)]          
3)      libignition-common4-av-dev [4.5.0-1~bionic (now)]      
4)      libignition-common4-core-dev [4.5.0-1~bionic (now)]    
5)      libignition-common4-events [4.5.0-1~bionic (now)]      
6)      libignition-common4-events-dev [4.5.0-1~bionic (now)]  
7)      libignition-common4-graphics [4.5.0-1~bionic (now)]    
8)      libignition-common4-graphics-dev [4.5.0-1~bionic (now)]
9)      libignition-common4-profiler [4.5.0-1~bionic (now)]    
10)     libignition-common4-profiler-dev [4.5.0-1~bionic (now)]
```

I guess breaking the unnumbered `libignition-common-dev` from libignition-common4-profiler-dev is a typo as no other -dev components specify this.